### PR TITLE
Include Tekton tasks and pipelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
       registry-server: ghcr.io
       registry-username: ${{ github.actor }}
       image: ${{ github.repository }}
-      version: 0.8.0
+      version: 0.9.0
     secrets:
       pull-request-token: ${{ secrets.GH_ORG_PAT }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It handles several activities like source code watching, testing, building, scan
 
 ### Dependencies
 
-Cartographer Supply Chains requires the [Cartographer](https://github.com/kadras-io/package-for-cartographer), [Tekton Pipelines](https://github.com/kadras-io/package-for-tekton-pipelines) and [Tekton Catalog](https://github.com/kadras-io/tekton-catalog) packages. You can install them from the [Kadras package repository](https://github.com/kadras-io/kadras-packages).
+Cartographer Supply Chains requires the [Cartographer](https://github.com/kadras-io/package-for-cartographer) and [Tekton Pipelines](https://github.com/kadras-io/package-for-tekton-pipelines) packages. You can install them from the [Kadras package repository](https://github.com/kadras-io/kadras-packages).
 
 ### Installation
 
@@ -107,7 +107,6 @@ The Cartographer Supply Chains package has the following configurable properties
 | `service_account` | `supply-chain` | The default `ServiceAccount` used by the supply chain. |
 | `ca_cert_data` | `""` | PEM-encoded certificate data to trust TLS connections with a custom CA. |
 | `cluster_builder` | `default` | The default `ClusterBuilder` used by kpack. |
-| `tekton_catalog_namespace` | `tekton-catalog` | The namespace where the Tekton Catalog package has been installed. |
 | `external_delivery` | `false` | Whether the application should delivered and deployed automatically on the current Kubernetes cluster or manually to an external cluster. |
 | `git_credentials_secret` | `""` | The Secret containing authentication credentials for Git repositories. |
 | `registry_credentials_secret` | `""` | The Secret containing authentication credentials for the OCI registry. |

--- a/package/config/helpers.star
+++ b/package/config/helpers.star
@@ -7,3 +7,7 @@ def config_writer():
   end
   return "tekton-write-config-template"
 end
+
+def tekton_catalog_namespace():
+  return "cartographer-tekton-catalog"
+end

--- a/package/config/kbld-config.yml
+++ b/package/config/kbld-config.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+
+#! Search rules specify custom strategies for kbld to identify references for container images.
+#! See more about the search rules: https://carvel.dev/kbld/docs/latest/config/#search-rules.
+searchRules:
+
+  # Resolves the image references from the Tekton tasks.
+  - keyMatcher: 
+      name: image
+      path: [spec, steps, {allIndexes: true}]

--- a/package/config/supply-chains/supply-chain-basic.yml
+++ b/package/config/supply-chains/supply-chain-basic.yml
@@ -1,5 +1,4 @@
 #@ load("@ytt:data", "data")
-#@ load("/helpers.star", "config_writer")
 
 #@ if/end data.values.supply_chain == "basic" and "source-to-url-basic" not in data.values.excluded_blueprints:
 ---

--- a/package/config/tekton-catalog/config-writer/git-write-config-and-pr-task.yml
+++ b/package/config/tekton-catalog/config-writer/git-write-config-and-pr-task.yml
@@ -1,0 +1,152 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: git-write-config-and-pr
+spec:
+  description: |-
+    Consumes application deployment configuration files as a Base64-encoded JSON,
+    pushes them to a Git repository under a given path, and opens a pull request
+    to merge the changes into a given target branch.
+  params:
+    - name: repository_owner
+      description: The owner of the Git repository (username or organization name).
+      type: string
+    - name: repository_name
+      description: The name of the Git repository.
+      type: string
+    - name: commit_branch
+      description: The branch to use to open a pull request. If empty, a random name is generated.
+      type: string
+    - name: git_user_email
+      description: The email of the user interacting with the Git repository.
+      type: string
+      default: "cartographer@kadras.io"
+    - name: git_user_name
+      description: The name of the user interacting with the Git repository.
+      type: string
+      default: "cartographer"
+    - name: git_commit_message
+      description: The commit message to use when pushing configuration changes to Git.
+      type: string
+      default: "Update from Cartographer"
+    - name: git_files
+      description: The configuration files to push to the Git repository, provided as a Base64-encoded JSON map.
+      type: string
+    - name: git_server_address
+      type: string
+      description: The location of the server hosting the specified Git repository.
+      default: https://github.com
+    - name: git_server_kind
+      type: string
+      description: The type of Git server where to open the pull request (e.g. github, gitlab, gitea).
+      default: github
+    - name: pull_request_title
+      type: string
+      description: The title of the pull request.
+    - name: pull_request_body
+      type: string
+      description: The message body of the pull request.
+      default: ""
+    - name: base_branch
+      type: string
+      description: The target branch where to push configuration changes.
+      default: main
+    - name: sub_path
+      description: The path in the Git repository where to write the configuration files.
+      type: string
+      default: "config"
+  results:
+    - name: pr-url
+      description: The URL of the successfully created pull request.
+  workspaces:
+    - name: config-dir
+      mountPath: /workspace/config-dir
+    - name: repo-dir
+      mountPath: /workspaces/repo-dir
+  steps:
+    - name: prepare-config-files
+      image: paketobuildpacks/build-jammy-base
+      workingDir: /tekton/home
+      securityContext:
+        runAsNonRoot: true
+      script: |
+        #!/usr/bin/env sh
+
+        set -eu
+
+        echo '$(params.git_files)' | base64 -d > files.json
+        eval "$(cat files.json | jq -r 'to_entries | .[] | @sh "mkdir -p $(dirname \(.key)) && echo \(.value) > \(.key) && mv \(.key) $(workspaces.config-dir.path)/"')"
+
+    - name: git-commit-and-push
+      image: cgr.dev/chainguard/git
+      securityContext:
+        runAsNonRoot: true
+      script: |
+        #!/usr/bin/env sh
+
+        set -eux
+
+        # Configure Git
+        git config --global user.email "$(params.git_user_email)"
+        git config --global user.name "$(params.git_user_name)"
+
+        # Compute branch name
+        commit_branch="$(params.commit_branch)"
+        if [ -z "$commit_branch" ]; then
+          commit_branch=$(date +%s | base64)
+        fi
+
+        # Compute repository URI
+        git_repository="$(params.git_server_address)/$(params.repository_owner)/$(params.repository_name).git"
+
+        # Check out target branch or create it if it doesn't exist
+        if git clone --depth 1 -b $commit_branch $git_repository ./repo; then
+          cd ./repo
+        else
+          git clone --depth 1 $git_repository ./repo
+          cd ./repo
+          git checkout -b $commit_branch
+        fi
+
+        # Navigate to subpath
+        mkdir -p $(params.sub_path)
+        cd $(params.sub_path)
+
+        # Add configuration files
+        cp $(workspaces.config-dir.path)/* .
+        git add .
+
+        # Commit and push configuration files
+        git commit -m "$(params.git_commit_message)" --allow-empty
+        git push origin $commit_branch
+
+        # Export branch name
+        echo "$commit_branch" > /workspaces/repo-dir/commit_branch
+
+    - name: open-pr
+      image: ghcr.io/jenkins-x/jx-scm
+      workingDir: /tekton/home
+      script: |
+        #!/usr/bin/env sh
+
+        set -eu
+
+        head_branch=$(cat /workspaces/repo-dir/commit_branch | tr -d '\n')
+
+        token=$(cat $(credentials.path)/.git-credentials | sed -e 's/https:.*://' | sed -e 's/@.*//')
+
+        jx-scm pull-request create \
+          --kind "$(params.git_server_kind)" \
+          --server "$(params.git_server_address)" \
+          --token "$token" \
+          --owner "$(params.repository_owner)" \
+          --name "$(params.repository_name)" \
+          --head "$head_branch" \
+          --title "$(params.pull_request_title)" \
+          --body "$(params.pull_request_body)" \
+          --base "$(params.base_branch)" \
+          --allow-update 2>&1 |
+        tee stdoutAndSterr.txt
+
+        cat stdoutAndSterr.txt | sed -n -e 's/^.*\. url: //p' > $(results.pr-url.path)

--- a/package/config/tekton-catalog/config-writer/git-write-config-task.yml
+++ b/package/config/tekton-catalog/config-writer/git-write-config-task.yml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: git-write-config
+spec:
+  description: |-
+    Consumes application deployment configuration files as a Base64-encoded JSON and
+    pushes them to a Git repository under a given path.
+  params:
+    - name: git_repository
+      description: The Git repository where to push the configuration files.
+      type: string
+    - name: git_branch
+      description: The Git branch where to push the configuration files.
+      type: string
+      default: "main"
+    - name: git_user_email
+      description: The email of the user interacting with the Git repository.
+      type: string
+      default: "cartographer@kadras.io"
+    - name: git_user_name
+      description: The name of the user interacting with the Git repository.
+      type: string
+      default: "cartographer"
+    - name: git_commit_message
+      description: The commit message to use when pushing the configuration files to the Git repository.
+      type: string
+      default: "Update from Cartographer"
+    - name: sub_path
+      description: The path in the Git repository where to write the configuration files.
+      type: string
+      default: "config"
+    - name: git_files
+      description: The configuration files to push to the Git repository, provided as a Base64-encoded JSON map.
+      type: string
+  workspaces:
+    - name: config-dir
+      mountPath: /workspace/config-dir
+  steps:
+    - name: prepare-config-files
+      image: paketobuildpacks/build-jammy-base
+      workingDir: /tekton/home
+      securityContext:
+        runAsNonRoot: true
+      script: |
+        #!/usr/bin/env sh
+
+        set -eu
+
+        echo '$(params.git_files)' | base64 -d > files.json
+        eval "$(cat files.json | jq -r 'to_entries | .[] | @sh "mkdir -p $(dirname \(.key)) && echo \(.value) > \(.key) && mv \(.key) $(workspaces.config-dir.path)/"')"
+
+    - name: git-commit-and-push
+      image: cgr.dev/chainguard/git
+      securityContext:
+        runAsNonRoot: true
+      script: |
+        #!/usr/bin/env sh
+
+        set -eux
+
+        # Configure Git
+        git config --global user.email "$(params.git_user_email)"
+        git config --global user.name "$(params.git_user_name)"
+
+        # Check out target branch or create it if it doesn't exist
+        if git clone --depth 1 -b "$(params.git_branch)" "$(params.git_repository)" ./repo; then
+          cd ./repo
+        else
+          git clone --depth 1 "$(params.git_repository)" ./repo
+          cd ./repo
+          git checkout -b "$(params.git_branch)"
+        fi
+
+        # Navigate to subpath
+        mkdir -p $(params.sub_path)
+        cd $(params.sub_path)
+
+        # Add configuration files
+        cp $(workspaces.config-dir.path)/* .
+        git add .
+
+        # Commit and push configuration files
+        git commit -m "$(params.git_commit_message)" --allow-empty
+        git push origin $(params.git_branch)

--- a/package/config/tekton-catalog/config-writer/oci-write-config-task.yml
+++ b/package/config/tekton-catalog/config-writer/oci-write-config-task.yml
@@ -1,0 +1,71 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: oci-write-config
+spec:
+  description: |-
+    Consumes application deployment configuration files as a Base64-encoded JSON and
+    pushes them to an OCI registry as an OCI bundle (imgpkg artifact type).
+  params:
+    - name: bundle
+      description: The fully qualified name of the OCI repository where to push the configuration files.
+      type: string
+    - name: files
+      description: The configuration files to push to the OCI registry, provided as a Base64-encoded JSON map.
+      type: string
+    - name: ca_cert_data
+      description: PEM-encoded certificate data for the OCI Registry where to push the configuration files.
+      type: string
+      default: ""
+  workspaces:
+    - name: config-dir
+      mountPath: /workspace/config-dir
+  steps:
+    - name: prepare-config-files
+      image: paketobuildpacks/build-jammy-base
+      workingDir: /tekton/home
+      securityContext:
+        runAsNonRoot: true
+      script: |
+        #!/usr/bin/env sh
+
+        set -eu
+
+        echo '$(params.files)' | base64 -d > files.json
+        eval "$(cat files.json | jq -r 'to_entries | .[] | @sh "mkdir -p $(dirname \(.key)) && echo \(.value) > \(.key) && mv \(.key) $(workspaces.config-dir.path)/"')"
+    
+    - name: publish-oci-bundle
+      image: paketobuildpacks/build-jammy-base
+      workingDir: /tekton/home
+      securityContext:
+        runAsNonRoot: true
+      script: |
+        #!/usr/bin/env bash
+
+        set -eux
+
+        # Install imgpkg
+        mkdir local-bin/
+        curl -L https://carvel.dev/install.sh | K14SIO_INSTALL_BIN_DIR=local-bin bash
+        export PATH=$PWD/local-bin/:$PATH
+
+        # Initialize OCI bundle
+        mkdir -p .imgpkg
+        echo "---
+        apiVersion: imgpkg.carvel.dev/v1alpha1
+        kind: ImagesLock" > ./.imgpkg/images.yml
+
+        # Configure imgpkg
+        imgpkg_params=""
+        if [[ ! -z "$(params.ca_cert_data)" ]]; then
+          certs_dir=$(mktemp -d)
+          echo "$(params.ca_cert_data)" > $certs_dir/cert
+          imgpkg_params="--registry-ca-cert-path=$certs_dir/cert"
+        fi
+
+        # Add configuration files
+        cp $(workspaces.config-dir.path)/* .
+        
+        # Publish config bundle
+        imgpkg push $imgpkg_params -b $(params.bundle) -f .

--- a/package/config/tekton-catalog/namespace.yml
+++ b/package/config/tekton-catalog/namespace.yml
@@ -1,0 +1,21 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("/helpers.star", "tekton_catalog_namespace")
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: #@ tekton_catalog_namespace()
+
+#@overlay/match by=overlay.subset({"kind":"Pipeline"}), expects="1+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  namespace: #@ tekton_catalog_namespace()
+
+#@overlay/match by=overlay.subset({"kind":"Task"}), expects="1+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  namespace: #@ tekton_catalog_namespace()

--- a/package/config/tekton-catalog/scanning/grype-scan-image-task.yml
+++ b/package/config/tekton-catalog/scanning/grype-scan-image-task.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: grype-scan-image
+  labels:
+    app.kadras.io/task: scan
+    app.kadras.io/scanner: grype
+    app.kadras.io/target: image
+spec:
+  description: Scans a given OCI image for vulnerabilities with Grype.
+  params:
+    - name: image
+    - name: grype-args
+      default:
+        - "--only-fixed"
+  steps:
+    - name: scan
+      image: anchore/grype
+      args: ["$(params.image)", "$(params.grype-args[*])"]

--- a/package/config/tekton-catalog/scanning/grype-scan-source-task.yml
+++ b/package/config/tekton-catalog/scanning/grype-scan-source-task.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: grype-scan-source
+  labels:
+    app.kadras.io/task: scan
+    app.kadras.io/scanner: grype
+    app.kadras.io/target: source
+spec:
+  description: Scans a given application source code directory for vulnerabilities with Grype.
+  params:
+    - name: source-url
+    - name: source-revision
+    - name: source-subpath
+    - name: grype-args
+      default:
+        - "--only-fixed"
+  workspaces:
+    - name: source-dir
+      mountPath: /workspace/source-dir
+  steps:
+    - name: prepare
+      image: paketobuildpacks/build-jammy-base
+      workingDir: /tekton/home
+      securityContext:
+        runAsNonRoot: true
+      script: |-
+        cd `mktemp -d`
+        curl -SL $(params.source-url) | tar xvz -m
+        cd $(params.source-subpath)
+        mv * $(workspaces.source-dir.path)
+    - name: scan
+      image: anchore/grype
+      workingDir: $(workspaces.source-dir.path)
+      args: ["dir:.", "$(params.grype-args[*])"]

--- a/package/config/tekton-catalog/scanning/trivy-scan-image-task.yml
+++ b/package/config/tekton-catalog/scanning/trivy-scan-image-task.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: trivy-scan-image
+  labels:
+    app.kadras.io/task: scan
+    app.kadras.io/scanner: trivy
+    app.kadras.io/target: image
+spec:
+  description: Scans a given OCI image for vulnerabilities with Trivy.
+  params:
+    - name: image
+    - name: trivy-args
+      default:
+        - "--ignore-unfixed"
+  steps:
+    - name: scan
+      image: aquasec/trivy
+      args: ["image", "$(params.trivy-args[*])", "$(params.image)"]

--- a/package/config/tekton-catalog/scanning/trivy-scan-source-task.yml
+++ b/package/config/tekton-catalog/scanning/trivy-scan-source-task.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: trivy-scan-source
+  labels:
+    app.kadras.io/task: scan
+    app.kadras.io/scanner: trivy
+    app.kadras.io/target: source
+spec:
+  description: Scans a given application source code directory for vulnerabilities with Trivy.
+  params:
+    - name: source-url
+    - name: source-revision
+    - name: source-subpath
+    - name: trivy-args
+      default:
+        - "--ignore-unfixed"
+  workspaces:
+    - name: source-dir
+      mountPath: /workspace/source-dir
+  steps:
+    - name: prepare
+      image: paketobuildpacks/build-jammy-base
+      workingDir: /tekton/home
+      securityContext:
+        runAsNonRoot: true
+      script: |-
+        cd `mktemp -d`
+        curl -SL $(params.source-url) | tar xvz -m
+        cd $(params.source-subpath)
+        mv * $(workspaces.source-dir.path)
+    - name: scan
+      image: aquasec/trivy
+      workingDir: $(workspaces.source-dir.path)
+      args: ["fs", "$(params.trivy-args[*])", "."]

--- a/package/config/tekton-catalog/testing/golang-test-pipeline.yml
+++ b/package/config/tekton-catalog/testing/golang-test-pipeline.yml
@@ -1,0 +1,37 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: go-test-pipeline
+  labels:
+    app.kadras.io/pipeline: test
+    app.kadras.io/language: golang
+spec:
+  description: Runs tests for a Go application.
+  params:
+    - name: source-url
+    - name: source-revision
+    - name: source-subpath
+  tasks:
+    - name: test
+      params:
+        - name: source-url
+          value: $(params.source-url)
+        - name: source-revision
+          value: $(params.source-revision)
+        - name: source-subpath
+          value: $(params.source-subpath)
+      taskSpec:
+        params:
+          - name: source-url
+          - name: source-revision
+          - name: source-subpath
+        steps:
+          - name: test
+            image: cgr.dev/chainguard/go
+            securityContext:
+              runAsNonRoot: true
+            script: |-
+              wget -qO- $(params.source-url) | tar xvz -m
+              cd $(params.source-subpath)
+              go test

--- a/package/config/tekton-catalog/testing/java-test-pipeline.yml
+++ b/package/config/tekton-catalog/testing/java-test-pipeline.yml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: java-test-pipeline
+  labels:
+    app.kadras.io/pipeline: test
+    app.kadras.io/language: java
+spec:
+  description: Runs tests for a Java application using Gradle or Maven.
+  params:
+    - name: source-url
+    - name: source-revision
+    - name: source-subpath
+  tasks:
+    - name: test
+      params:
+        - name: source-url
+          value: $(params.source-url)
+        - name: source-revision
+          value: $(params.source-revision)
+        - name: source-subpath
+          value: $(params.source-subpath)
+      taskSpec:
+        params:
+          - name: source-url
+          - name: source-revision
+          - name: source-subpath
+        steps:
+          - name: test
+            image: cgr.dev/chainguard/jdk
+            securityContext:
+              runAsNonRoot: true
+            script: |-
+              wget -qO- $(params.source-url) | tar xvz -m
+              cd $(params.source-subpath)
+              if [ -f gradlew ]; then
+                chmod +x ./gradlew
+                ./gradlew build --no-daemon
+              elif [ -f mvnw ]; then
+                chmod +x ./mvnw
+                ./mvnw test
+              else
+                echo "ERROR. This pipeline supports only Java projects using the Maven or Gradle wrappers."
+                exit 1
+              fi

--- a/package/config/templates/config-writer/tekton-write-config-and-pr-template.yml
+++ b/package/config/templates/config-writer/tekton-write-config-and-pr-template.yml
@@ -1,4 +1,5 @@
 #@ load("@ytt:data", "data")
+#@ load("/helpers.star", "tekton_catalog_namespace")
 
 #@ if/end "tekton-write-config-and-pr-template" not in data.values.excluded_blueprints:
 ---
@@ -16,7 +17,7 @@ spec:
     - name: gitops
       default: {}
     - name: pipelineCatalogNamespace
-      default: #@ data.values.tekton_catalog_namespace
+      default: #@ tekton_catalog_namespace()
     - name: serviceAccount
       default: default
 

--- a/package/config/templates/config-writer/tekton-write-config-template.yml
+++ b/package/config/templates/config-writer/tekton-write-config-template.yml
@@ -1,4 +1,5 @@
 #@ load("@ytt:data", "data")
+#@ load("/helpers.star", "tekton_catalog_namespace")
 
 #@ if/end "tekton-write-config-template" not in data.values.excluded_blueprints:
 ---
@@ -17,7 +18,7 @@ spec:
     - name: gitops
       default: {}
     - name: pipelineCatalogNamespace
-      default: #@ data.values.tekton_catalog_namespace
+      default: #@ tekton_catalog_namespace()
     - name: registry
       default: {}
     - name: serviceAccount

--- a/package/config/templates/scanning/tekton-scan-image-template.yml
+++ b/package/config/templates/scanning/tekton-scan-image-template.yml
@@ -1,4 +1,5 @@
 #@ load("@ytt:data", "data")
+#@ load("/helpers.star", "tekton_catalog_namespace")
 
 #@ if/end "tekton-scan-image-template" not in data.values.excluded_blueprints:
 ---
@@ -15,7 +16,7 @@ spec:
     - name: scannerName
       default: trivy
     - name: pipelineCatalogNamespace
-      default: #@ data.values.tekton_catalog_namespace
+      default: #@ tekton_catalog_namespace()
     - name: serviceAccount
       default: default
   

--- a/package/config/templates/scanning/tekton-scan-source-template.yml
+++ b/package/config/templates/scanning/tekton-scan-source-template.yml
@@ -1,4 +1,5 @@
 #@ load("@ytt:data", "data")
+#@ load("/helpers.star", "tekton_catalog_namespace")
 
 #@ if/end "tekton-scan-source-template" not in data.values.excluded_blueprints:
 ---
@@ -15,7 +16,7 @@ spec:
     - name: scannerName
       default: trivy
     - name: pipelineCatalogNamespace
-      default: #@ data.values.tekton_catalog_namespace
+      default: #@ tekton_catalog_namespace()
     - name: serviceAccount
       default: default
 

--- a/package/config/templates/testing/tekton-test-source-template.yml
+++ b/package/config/templates/testing/tekton-test-source-template.yml
@@ -1,4 +1,5 @@
 #@ load("@ytt:data", "data")
+#@ load("/helpers.star", "tekton_catalog_namespace")
 
 #@ if/end "tekton-test-source-template" not in data.values.excluded_blueprints:
 ---
@@ -15,7 +16,7 @@ spec:
     - name: pipelineName
       default: ""
     - name: pipelineCatalogNamespace
-      default: #@ data.values.tekton_catalog_namespace
+      default: #@ tekton_catalog_namespace()
     - name: serviceAccount
       default: default
 

--- a/package/config/values-schema.yml
+++ b/package/config/values-schema.yml
@@ -14,9 +14,6 @@ ca_cert_data: ""
 #@schema/desc "The default `ClusterBuilder` used by kpack."
 cluster_builder: default
 
-#@schema/desc "The namespace where the Tekton Catalog package has been installed."
-tekton_catalog_namespace: tekton-catalog
-
 #@schema/desc "Whether the application should delivered and deployed automatically on the current Kubernetes cluster or manually to an external cluster."
 external_delivery: false
 

--- a/test/integration/default/00-assert.yaml
+++ b/test/integration/default/00-assert.yaml
@@ -1,4 +1,10 @@
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cartographer-tekton-catalog
+
+---
 apiVersion: carto.run/v1alpha1
 kind: ClusterSupplyChain
 metadata:

--- a/test/integration/kuttl-test.yml
+++ b/test/integration/kuttl-test.yml
@@ -17,18 +17,23 @@ commands:
   - script: |
       kubectl config set-context --current --namespace=tests && \
       kapp deploy -a secretgen-controller-package -y \
-        -f https://github.com/kadras-io/package-for-secretgen-controller/releases/download/v0.15.0/package.yml \
-        -f https://github.com/kadras-io/package-for-secretgen-controller/releases/download/v0.15.0/metadata.yml
+        -f https://github.com/kadras-io/package-for-secretgen-controller/releases/download/v0.15.1/package.yml \
+        -f https://github.com/kadras-io/package-for-secretgen-controller/releases/download/v0.15.1/metadata.yml
   - script: |
       kubectl config set-context --current --namespace=tests && \
       kapp deploy -a cert-manager-package -y \
-        -f https://github.com/kadras-io/package-for-cert-manager/releases/download/v1.13.1/package.yml \
-        -f https://github.com/kadras-io/package-for-cert-manager/releases/download/v1.13.1/metadata.yml
+        -f https://github.com/kadras-io/package-for-cert-manager/releases/download/v1.13.2/package.yml \
+        -f https://github.com/kadras-io/package-for-cert-manager/releases/download/v1.13.2/metadata.yml
   - script: |
       kubectl config set-context --current --namespace=tests && \
       kapp deploy -a cartographer-package -y \
-        -f https://github.com/kadras-io/package-for-cartographer/releases/download/v0.8.2/package.yml \
-        -f https://github.com/kadras-io/package-for-cartographer/releases/download/v0.8.2/metadata.yml
+        -f https://github.com/kadras-io/package-for-cartographer/releases/download/v0.8.5/package.yml \
+        -f https://github.com/kadras-io/package-for-cartographer/releases/download/v0.8.5/metadata.yml
+  - script: |
+      kubectl config set-context --current --namespace=tests && \
+      kapp deploy -a tekton-pipelines-package -y \
+        -f https://github.com/kadras-io/package-for-tekton-pipelines/releases/download/v0.53.0/package.yml \
+        -f https://github.com/kadras-io/package-for-tekton-pipelines/releases/download/v0.53.0/metadata.yml
   - script: |
       kubectl config set-context --current --namespace=tests && \
       kapp deploy -a dependencies -y -f ./test/setup/dependencies

--- a/test/setup/dependencies/cert-manager.yml
+++ b/test/setup/dependencies/cert-manager.yml
@@ -12,4 +12,4 @@ spec:
   packageRef:
     refName: cert-manager.packages.kadras.io
     versionSelection:
-      constraints: 1.13.1
+      constraints: 1.13.2

--- a/test/setup/dependencies/secretgen-controller.yml
+++ b/test/setup/dependencies/secretgen-controller.yml
@@ -12,4 +12,4 @@ spec:
   packageRef:
     refName: secretgen-controller.packages.kadras.io
     versionSelection:
-      constraints: 0.15.0
+      constraints: 0.15.1

--- a/test/setup/dependencies/tekton-pipelines.yml
+++ b/test/setup/dependencies/tekton-pipelines.yml
@@ -2,15 +2,14 @@
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall
 metadata:
-  name: cartographer
+  name: tekton-pipelines
   namespace: tests
   annotations:
-    kapp.k14s.io/change-group: cartographer
-    kapp.k14s.io/change-rule.cert-manager: upsert after upserting cert-manager
+    kapp.k14s.io/change-group: tekton-pipelines
     kapp.k14s.io/change-rule.serviceaccount: delete before deleting serviceaccount
 spec:
   serviceAccountName: kadras-install-sa
   packageRef:
-    refName: cartographer.packages.kadras.io
+    refName: tekton-pipelines.packages.kadras.io
     versionSelection:
-      constraints: 0.8.5
+      constraints: 0.53.0


### PR DESCRIPTION
Transfer the Tekton tasks and pipelines previously provided by the tekton-catalog package, which is now deprecated.

Update test dependencies.